### PR TITLE
Add vscode launch configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch iOS",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run", "ios"],
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Android",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run", "android"],
+        }
+    ]
+}


### PR DESCRIPTION
With the added launch configurations, we can now use VSCode to launch the app directly for us (instead of running `npm run ios` in terminal by ourselves):

<img width="1338" alt="image" src="https://github.com/user-attachments/assets/cd7bd9e3-a750-4596-a980-a4c4b7cb2938">

When the `run` button is clicked on the top-left corner, the app will be launched and the simulators will also be opened if not opened already.