### PR TITLE
Support adding items to order

### DIFF
--- a/components/CustomizationMenu.tsx
+++ b/components/CustomizationMenu.tsx
@@ -12,13 +12,13 @@ import Button from "./common/Button"
 import Colors from "@constants/colors"
 import MenuItem from "./menu/MenuItem"
 
-type ItemCustomizationProps = {
+type CustomizationMenuProps = {
   item?: MenuItemType
   onConfirm?: (event: GestureResponderEvent) => void
   onCancel?: (event: GestureResponderEvent) => void
 }
 
-const ItemCustomization: FC<ItemCustomizationProps> = ({
+const CustomizationMenu: FC<CustomizationMenuProps> = ({
   item,
   onConfirm = () => {},
   onCancel = () => {},
@@ -63,7 +63,7 @@ const ItemCustomization: FC<ItemCustomizationProps> = ({
   )
 }
 
-export default ItemCustomization
+export default CustomizationMenu
 
 const styles = StyleSheet.create({
   button: {

--- a/components/ItemCustomization.tsx
+++ b/components/ItemCustomization.tsx
@@ -24,8 +24,8 @@ const ItemCustomization: FC<ItemCustomizationProps> = ({
   onCancel = () => {},
 }) => {
   const options = item?.customizatioinOptions ?? []
-  const customizationOptions = options.map(({ name, price, color }) => (
-    <MenuItem key={name} name={name} price={price} color={color} />
+  const customizationOptions = options.map((option) => (
+    <MenuItem key={option.name} {...option} />
   ))
 
   return (

--- a/components/menu/Menu.tsx
+++ b/components/menu/Menu.tsx
@@ -23,10 +23,7 @@ const Menu: FC<MenuProps> = ({ items = [] }) => {
     return (
       <MenuItem
         key={item.name}
-        name={item.name}
-        price={item.price}
-        color={item.color}
-        customizatioinOptions={item.customizatioinOptions}
+        {...item}
         onPress={() => {
           if ((item.customizatioinOptions ?? []).length > 0) {
             setCustomizationMenu({ item })

--- a/components/menu/Menu.tsx
+++ b/components/menu/Menu.tsx
@@ -10,14 +10,23 @@ type MenuProps = {
   items?: MenuItemType[]
 }
 
-type CustomizationMenuState = {
-  item?: MenuItemType
-}
-
 const Menu: FC<MenuProps> = ({ items = [] }) => {
-  const [customizationMenu, setCustomizationMenu] = useState(
-    {} as CustomizationMenuState
+  const [selectedItem, setSelectedItem] = useState(
+    null as MenuItemType | null
   )
+
+  const customizationMenu = (selectedItem) ? (
+    <CustomizationMenu
+      item={selectedItem}
+      onConfirm={() => {
+        // TODO: add item to order
+        setSelectedItem(null)
+      }}
+      onCancel={() => {
+        setSelectedItem(null)
+      }}
+    />
+  ) : null
 
   const menuItems = items.map((item) => {
     return (
@@ -26,7 +35,7 @@ const Menu: FC<MenuProps> = ({ items = [] }) => {
         {...item}
         onPress={() => {
           if ((item.customizatioinOptions ?? []).length > 0) {
-            setCustomizationMenu({ item })
+            setSelectedItem(item)
           } else {
             // TODO: directly add the item to the order
           }
@@ -37,15 +46,7 @@ const Menu: FC<MenuProps> = ({ items = [] }) => {
 
   return (
     <View style={styles.background}>
-      <CustomizationMenu
-        item={customizationMenu.item}
-        onConfirm={() => {
-          // TODO: add item to order
-        }}
-        onCancel={() => {
-          setCustomizationMenu({})
-        }}
-      />
+      {customizationMenu}
       <View>
         <MenuCategories categories={sampleMenuCategories} />
       </View>

--- a/components/menu/Menu.tsx
+++ b/components/menu/Menu.tsx
@@ -2,9 +2,9 @@ import { FC, useState } from "react"
 import { View, ScrollView, StyleSheet } from "react-native"
 
 import { MenuItemType, sampleMenuCategories } from "@lib/sample-data"
-import ItemCustomization from "../ItemCustomization"
-import MenuItem from "./MenuItem"
+import CustomizationMenu from "../CustomizationMenu"
 import MenuCategories from "./MenuCategories"
+import MenuItem from "./MenuItem"
 
 type MenuProps = {
   items?: MenuItemType[]
@@ -37,7 +37,7 @@ const Menu: FC<MenuProps> = ({ items = [] }) => {
 
   return (
     <View style={styles.background}>
-      <ItemCustomization
+      <CustomizationMenu
         item={customizationMenu.item}
         onConfirm={() => {
           // TODO: add item to order

--- a/components/menu/Menu.tsx
+++ b/components/menu/Menu.tsx
@@ -8,9 +8,10 @@ import MenuItem from "./MenuItem"
 
 type MenuProps = {
   items?: MenuItemType[]
+  onAddItem?: (item: MenuItemType) => void
 }
 
-const Menu: FC<MenuProps> = ({ items = [] }) => {
+const Menu: FC<MenuProps> = ({ items = [], onAddItem = () => {} }) => {
   const [selectedItem, setSelectedItem] = useState(
     null as MenuItemType | null
   )
@@ -19,8 +20,8 @@ const Menu: FC<MenuProps> = ({ items = [] }) => {
     <CustomizationMenu
       item={selectedItem}
       onConfirm={() => {
-        // TODO: add item to order
         setSelectedItem(null)
+        onAddItem(selectedItem)
       }}
       onCancel={() => {
         setSelectedItem(null)
@@ -37,7 +38,7 @@ const Menu: FC<MenuProps> = ({ items = [] }) => {
           if ((item.customizatioinOptions ?? []).length > 0) {
             setSelectedItem(item)
           } else {
-            // TODO: directly add the item to the order
+            onAddItem(item)
           }
         }}
       />

--- a/components/menu/Menu.tsx
+++ b/components/menu/Menu.tsx
@@ -29,21 +29,19 @@ const Menu: FC<MenuProps> = ({ items = [], onAddItem = () => {} }) => {
     />
   ) : null
 
-  const menuItems = items.map((item) => {
-    return (
-      <MenuItem
-        key={item.name}
-        {...item}
-        onPress={() => {
-          if ((item.customizatioinOptions ?? []).length > 0) {
-            setSelectedItem(item)
-          } else {
-            onAddItem(item)
-          }
-        }}
-      />
-    )
-  })
+  const menuItems = items.map((item) => (
+    <MenuItem
+      key={item.name}
+      {...item}
+      onPress={() => {
+        if ((item.customizatioinOptions ?? []).length > 0) {
+          setSelectedItem(item)
+        } else {
+          onAddItem(item)
+        }
+      }}
+    />
+  ))
 
   return (
     <View style={styles.background}>

--- a/components/menu/MenuItem.tsx
+++ b/components/menu/MenuItem.tsx
@@ -21,11 +21,7 @@ const MenuItem: FC<MenuItemProps> = ({
   onPress = () => {},
 }) => {
   return (
-    <Pressable
-      onPress={(event) => {
-        if (customizatioinOptions.length > 0) onPress(event)
-      }}
-    >
+    <Pressable onPress={onPress} >
       <View
         aria-label="menu item"
         style={[styles.button, { backgroundColor: color }]}

--- a/components/order/OrderSummary.tsx
+++ b/components/order/OrderSummary.tsx
@@ -1,13 +1,18 @@
+import { FC } from "react"
 import { View, Text, StyleSheet } from "react-native"
 
 import { OrderItem } from "./OrderItem"
-import { sampleOrderItems } from "@lib/sample-data"
+import { OrderItemType } from "@lib/sample-data"
 import CheckoutOptions from "./CheckoutOptions"
 import Colors from "@constants/colors"
 import CustomerInstructions from "./CustomerInstructions"
 
-function OrderSummary() {
-  const orderItems = sampleOrderItems.map((item) => (
+type OrderSummaryProps = {
+  items?: OrderItemType[]
+}
+
+const OrderSummary: FC<OrderSummaryProps> = ({ items = [] }) => {
+  const orderItems = items.map((item) => (
     <OrderItem key={item.menuItem.name} {...item} />
   ))
 

--- a/components/order/OrderSummary.tsx
+++ b/components/order/OrderSummary.tsx
@@ -7,18 +7,9 @@ import Colors from "@constants/colors"
 import CustomerInstructions from "./CustomerInstructions"
 
 function OrderSummary() {
-  const orderItems = sampleOrderItems.map(
-    ({ menuItem, quantity, customizationOptions }) => {
-      return (
-        <OrderItem
-          key={menuItem.name}
-          menuItem={menuItem}
-          quantity={quantity}
-          customizationOptions={customizationOptions}
-        />
-      )
-    }
-  )
+  const orderItems = sampleOrderItems.map((item) => (
+    <OrderItem key={item.menuItem.name} {...item} />
+  ))
 
   return (
     <View style={styles.background}>

--- a/components/order/Receipt.tsx
+++ b/components/order/Receipt.tsx
@@ -83,6 +83,7 @@ type ReceiptItemProps = {
   price: string
   customization?: string
 }
+
 const ReceiptItem = (props: ReceiptItemProps) => {
   // Receipt item without customization options
   let item = (

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react"
 import { View, StyleSheet } from "react-native"
 
 import { sampleMenuItems } from "@lib/sample-data"
@@ -5,21 +6,19 @@ import TitleBar from "@components/TitleBar"
 import Menu from "@components/menu/Menu"
 import OrderSummary from "@components/order/OrderSummary"
 
-function RegisterScreen() {
-  return (
-    <View style={styles.register}>
-      <TitleBar />
-      <View style={styles.menuAndSummary}>
-        <View style={styles.menu}>
-          <Menu items={sampleMenuItems} />
-        </View>
-        <View style={styles.orderSummary}>
-          <OrderSummary />
-        </View>
+const RegisterScreen: FC = () => (
+  <View style={styles.register}>
+    <TitleBar />
+    <View style={styles.menuAndSummary}>
+      <View style={styles.menu}>
+        <Menu items={sampleMenuItems} />
+      </View>
+      <View style={styles.orderSummary}>
+        <OrderSummary />
       </View>
     </View>
-  )
-}
+  </View>
+)
 
 export default RegisterScreen
 

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -1,24 +1,29 @@
-import { FC } from "react"
+import { FC, useState } from "react"
 import { View, StyleSheet } from "react-native"
 
-import { sampleMenuItems } from "@lib/sample-data"
+import { sampleMenuItems, sampleOrderItems } from "@lib/sample-data"
 import TitleBar from "@components/TitleBar"
 import Menu from "@components/menu/Menu"
 import OrderSummary from "@components/order/OrderSummary"
 
-const RegisterScreen: FC = () => (
-  <View style={styles.register}>
-    <TitleBar />
-    <View style={styles.menuAndSummary}>
-      <View style={styles.menu}>
-        <Menu items={sampleMenuItems} />
-      </View>
-      <View style={styles.orderSummary}>
-        <OrderSummary />
+const RegisterScreen: FC = () => {
+  const [menuItems, setMenuItems] = useState(sampleMenuItems)
+  const [orderItems, setOrderItems] = useState(sampleOrderItems)
+
+  return (
+    <View style={styles.register}>
+      <TitleBar />
+      <View style={styles.menuAndSummary}>
+        <View style={styles.menu}>
+          <Menu items={menuItems} />
+        </View>
+        <View style={styles.orderSummary}>
+          <OrderSummary items={orderItems} />
+        </View>
       </View>
     </View>
-  </View>
-)
+  )
+}
 
 export default RegisterScreen
 

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -15,7 +15,12 @@ const RegisterScreen: FC = () => {
       <TitleBar />
       <View style={styles.menuAndSummary}>
         <View style={styles.menu}>
-          <Menu items={menuItems} />
+          <Menu items={menuItems} onAddItem={(item) => {
+            setOrderItems([
+              ...orderItems,
+              { menuItem: item, quantity: 1 }
+            ])
+          }} />
         </View>
         <View style={styles.orderSummary}>
           <OrderSummary items={orderItems} />


### PR DESCRIPTION
- Renamed `ItemCustomization` to `CustomizationMenu` to allow future reuse of the component
- Simplify props passing by using spread `...` syntax
- Define `onAddItem` on `Menu` which will be called when a user wants to add an item to the menu
- Update `RegisterScreen` to add items to order when menu items are chosen